### PR TITLE
Add Text Ranges to Extraction Results

### DIFF
--- a/zdai/api/extractionapi.py
+++ b/zdai/api/extractionapi.py
@@ -78,6 +78,8 @@ class ExtractionAPI(object):
                     results.append(FieldExtractionResult(
                         field_id = result.field_id,
                         text = extraction.text,
+                        text_start = span.start,
+                        text_end = span.end,
                         page_start = span.pages.start,
                         page_end = span.pages.end,
                         top = span.bounds.top,

--- a/zdai/models/field_extraction_result.py
+++ b/zdai/models/field_extraction_result.py
@@ -22,6 +22,8 @@ class FieldExtractionResult:
     """
     field_id: str = None
     text: str = None
+    text_start: int = None
+    text_end: int = None
     page_start: int = None
     page_end: int = None
     top: int = None


### PR DESCRIPTION
This PR updates FieldExtractionResult so that it exposes the text_start and text_end, which came from the Extraction response.