### PR TITLE
Fix extraction results spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ while len(requests) > 0:
                 print(f'Finished: {request.language}')
             elif request.is_type(FieldExtractionRequest):
                 for result in request.get_results():
-                    print(result.field_id, result.text)
+                    print(result.field_id, result.text, result.spans)
 
             requests.remove(request)
     time.sleep(2)

--- a/zdai/models/field_extraction_result.py
+++ b/zdai/models/field_extraction_result.py
@@ -12,7 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class FieldExtractionResultSpan:
+    """
+    Dataclass to store the properties associated with a field extraction result span
+    """
+    text_start: int = None
+    text_end: int = None
+    page_start: int = None
+    page_end: int = None
+    top: int = None
+    left: int = None
+    bottom: int = None
+    right: int = None
 
 
 @dataclass
@@ -22,11 +38,4 @@ class FieldExtractionResult:
     """
     field_id: str = None
     text: str = None
-    text_start: int = None
-    text_end: int = None
-    page_start: int = None
-    page_end: int = None
-    top: int = None
-    left: int = None
-    bottom: int = None
-    right: int = None
+    spans: List[FieldExtractionResultSpan] = field(default_factory = lambda: [])


### PR DESCRIPTION
Some fields such as `Parties` and `Date` can at times return an extraction that contains multiple spans. The `ExtractionAPI` wrapper was not taking this into account, and would duplicate instances of `FieldExtractionResult` unnecessarily. It would look as-though DocAI returned duplicate `text` extractions, when it was not the case. With this change, the `spans` are now accessible through `FieldExtractionResult.spans` which means there's now only ever one `FieldExtractionResult` per field, with (potentially) multiple `spans` as one of its properties.