### PR TITLE
Omit OCR layout key when none is specified

### DIFF
--- a/zdai/api/ocrapi.py
+++ b/zdai/api/ocrapi.py
@@ -26,7 +26,7 @@ class OCRAPI(object):
     def __init__(self, token: str, url: str):
         self._call = ApiCall(token, url)
 
-    def create(self, file_ids: List[str], generate_layout: bool = False) -> Tuple[List[OCRRequest], ApiCall]:
+    def create(self, file_ids: List[str], generate_layout: bool = None) -> Tuple[List[OCRRequest], ApiCall]:
         """
         Creates a new OCR request for the file ids provided.
 
@@ -34,7 +34,9 @@ class OCRAPI(object):
         """
         caller = self._call.new(method = 'POST', path = 'ocr')
         caller.add_body(key = 'file_ids', value = file_ids)
-        caller.add_body(key = 'layout', value = generate_layout)
+        if generate_layout != None:
+            caller.add_body(key = 'layout', value = generate_layout)
+
         caller.send()
 
         return [OCRRequest(api = self, json = c) for c in caller.response.json().get('file_ids')], caller


### PR DESCRIPTION
If the user hasn't specified the value of the layout flag when creating
an OCR request, we should omit the flag from the request and let the
server provide the default behaviour.