### PR TITLE
New wrapper function to call get_layouts

### DIFF
--- a/zdai/models/ocr_request.py
+++ b/zdai/models/ocr_request.py
@@ -26,3 +26,7 @@ class OCRRequest(BaseRequest):
     def get_images(self):
         data = self.api().get_images(request_id = self.id)
         return data
+
+    def get_layouts(self):
+        data = self.api().get_layouts(request_id = self.id)
+        return data


### PR DESCRIPTION
Add `get_layouts` in `OCRRequest` to call `OCRAPI.get_layouts`.

This would be a breaking change I believe but shouldn't `OCRAPI.get_images` and `OCRAPI.get_layouts` both use:
```py
return caller.response.content
```
to return the bytes of the image zip and the protobuf layouts instead of returning an `ApiCall`?