### PR TITLE
Added Duration and Currency normalization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Wrapper
 
-The API wrapper is designed to reflect the decoupled nature of ZDAI's microservices. Meaning, there is one wrapper 
+The API wrapper is designed to reflect the decoupled nature of ZDAI's microservices. Meaning, there is one wrapper
 class for each microservice.
 
 ## Setup
@@ -131,7 +131,7 @@ mlc_status, _ = sdk.mlc.get(request_id = mlc_jobs[0].id)
 for mlc in mlc_jobs:
     if mlc.is_successful():
         print(f'{mlc.classification_1}, {mlc.classification_2}, {mlc.classification_3}')
-    
+
 
 ```
 
@@ -239,7 +239,7 @@ for phrase in date_phrases:
 ```
 
 # Currency Normalization
-DocAI can be used to normalize strings that contain dates, so that the `value` and `symbol` are returned.
+DocAI can be used to normalize strings that contain currencies, so that the `value` and `symbol` are returned.
 
 ```python
 from zdai import ZDAISDK
@@ -261,7 +261,7 @@ for phrase in currency_phrases:
 ```
 
 # Duration Normalization
-DocAI can be used to normalize strings that contain dates, so that the `value` and `unit` are returned.
+DocAI can be used to normalize strings that contain durations, so that the `value` and `unit` are returned.
 
 ```python
 from zdai import ZDAISDK

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ DocAI can be used to normalize strings that contain dates, so that the `year`, `
 
 ```python
 from zdai import ZDAISDK
-import json
 
 sdk = ZDAISDK(from_config = True)
 
@@ -236,6 +235,52 @@ for phrase in date_phrases:
 
     for date in response.dates:
         print(f'[{date.year}-{date.month}-{date.day}] {response.text}')
+
+```
+
+# Currency Normalization
+DocAI can be used to normalize strings that contain dates, so that the `value` and `symbol` are returned.
+
+```python
+from zdai import ZDAISDK
+
+sdk = ZDAISDK(from_config = True)
+
+currency_phrases = [
+      "The landlord is charging two thousand five hundred dollars",
+      "The mortgage owner agrees to pay a value of three hundred and fifty euros per month",
+      "During their trip to Korea, the couple agreed to pay the establishment 500 Won per day",
+      "The agreement defines the Payment to be nine hundred and ten million five hundred and one thousand five hundred and fifty five dollars"
+    ]
+
+for phrase in currency_phrases:
+    response, _ = sdk.normalization.get_currencies(text = phrase)
+
+    for currency in response.currencies:
+        print(f'[{currency.symbol} {currency.value}] {response.text}')
+```
+
+# Duration Normalization
+DocAI can be used to normalize strings that contain dates, so that the `value` and `unit` are returned.
+
+```python
+from zdai import ZDAISDK
+
+sdk = ZDAISDK(from_config = True)
+
+duration_phrases = [
+    "This agreement between the two counterparties will expire two years after its execution",
+    "The owner of the agreement must pay the client the after the 5th anniversary of its execution",
+    "The lendee, after five weeks of obtaining the loan, will begin paying interest",
+    "The interest of this agreement will increase by .5% after three years",
+    "My birthday starts six (6) days into the month of April"
+]
+
+for phrase in duration_phrases:
+    response, _ = sdk.normalization.get_durations(text = phrase)
+
+    for duration in response.durations:
+        print(f'[{duration.value} {duration.unit}] {response.text}')
 
 ```
 

--- a/zdai/api/normalizationapi.py
+++ b/zdai/api/normalizationapi.py
@@ -16,6 +16,8 @@ from typing import Tuple
 
 from ..api.apicall import ApiCall
 from ..models.date_normalization import DateNormalization
+from ..models.currency_normalization import CurrencyNormalization
+from ..models.duration_normalization import DurationNormalization
 
 
 class NormalizationAPI(object):
@@ -38,3 +40,29 @@ class NormalizationAPI(object):
         caller.send()
 
         return DateNormalization(api = self, json = caller.response.json()), caller
+
+    def get_durations(self, text: str) -> tuple[DurationNormalization, ApiCall]:
+        """
+        Gets the normalized duration values from the input string
+
+        :return:
+        """
+
+        caller = self._call.new(method = 'POST', path = 'normalize/duration')
+        caller.add_body(key = 'text', value = text)
+        caller.send()
+
+        return DurationNormalization(api = self, json = caller.response.json()), caller
+
+    def get_currencies(self, text: str) -> Tuple[CurrencyNormalization, ApiCall]:
+        """
+        Gets the normalized currency values from the input string
+
+        :return:
+        """
+
+        caller = self._call.new(method = 'POST', path = 'normalize/currency')
+        caller.add_body(key = 'text', value = text)
+        caller.send()
+
+        return CurrencyNormalization(api = self, json = caller.response.json()), caller

--- a/zdai/models/currency_normalization.py
+++ b/zdai/models/currency_normalization.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Zuva Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .basenormalization import BaseNormalization
+from dataclasses import dataclass
+
+@dataclass
+class Currency:
+    value: float
+    symbol: str
+    precision: int
+
+
+class CurrencyNormalization(BaseNormalization):
+    def __init__(self, api, json):
+        super().__init__(api = api, json = json)
+
+    @property
+    def _currencies(self):
+        return self.json().get('currency')
+
+    @property
+    def currencies(self):
+        currencies = []
+        for currency in self._currencies:
+            currencies.append(Currency(value = currency.get('value'),
+                                       symbol = currency.get('symbol'),
+                                       precision = currency.get('precision')))
+
+        return currencies

--- a/zdai/models/duration_normalization.py
+++ b/zdai/models/duration_normalization.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Zuva Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .basenormalization import BaseNormalization
+from dataclasses import dataclass
+
+
+@dataclass
+class Duration:
+    unit: str
+    value: int
+
+
+class DurationNormalization(BaseNormalization):
+    def __init__(self, api, json):
+        super().__init__(api = api, json = json)
+
+    @property
+    def _durations(self):
+        return self.json().get('duration')
+
+    @property
+    def durations(self):
+        durations = []
+        for duration in self._durations:
+            durations.append(Duration(unit = duration.get('unit'),
+                                      value = duration.get('value')))
+
+        return durations


### PR DESCRIPTION
In addition to `Date` Normalization, DocAI can be used to normalize `Currencies` and `Durations` from text strings.

This PR introduces these so that they can be used via the Python SDK.

These normalizers can be called by calling the `sdk.normalization.get_durations(...)` and `sdk.normalization.get_currencies(...)`

Examples are provided in the `readme.md`