### PR TITLE
Adds Normalization to Field Extraction Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,34 @@ while len(requests) > 0:
     time.sleep(2)
 ```
 
+### Obtain an extraction result's normalized values
+
+The API will return the normalized values for fields that have a `normalization_type` of `DATE`, `CURRENCY` or `DURATION`.
+
+The following is an example of a job poller (similar to the above), where the `result` variable is used to obtain the normalized
+values of the text that was extracted.
+
+```python
+while len(requests) > 0:
+    for request in requests:
+        print(request.type, request.id, request.status)
+        request.update()
+        if request.is_finished():
+            for result in request.get_results():
+                if result.is_normalized():
+                    normalized_type, values = result.get_normalized()
+                    if normalized_type == 'dates':
+                        print(f'Here are your dates, normalized: {values}')
+                    elif normalized_type == 'currencies':
+                        print(f'Here are your currencies, normalized: {values}')
+                    elif normalized_type == 'durations':
+                        print(f'Here are your durations, normalized: {values}')
+
+            requests.remove(request)
+
+    time.sleep(2)
+```
+
 ## Obtain a newly-submitted file's ID
 
 ```python

--- a/zdai/api/extractionapi.py
+++ b/zdai/api/extractionapi.py
@@ -16,7 +16,9 @@ from typing import List, Tuple
 
 from .apicall import ApiCall
 from ..models.field_extraction_request import FieldExtractionRequest
-from ..models.field_extraction_result import BoundingBoxesByPage, FieldExtractionResult, FieldExtractionResultDefinedTerm, FieldExtractionResultSpan
+from ..models.field_extraction_result import BoundingBoxesByPage, FieldExtractionResult, \
+    FieldExtractionResultDefinedTerm, FieldExtractionResultSpan, DurationNormalizedValues, \
+    CurrencyNormalizedValues, DateNormalizedValues
 from ..models.field_extraction_answer import FieldExtractionAnswer
 import json
 from types import SimpleNamespace
@@ -127,11 +129,39 @@ class ExtractionAPI(object):
 
                             defined_term.spans.append(defined_term_span)
 
+                # Set the field_id and the text that was extracted.
+                # The text can have null values.
                 extraction_result = FieldExtractionResult(
                     field_id=result.field_id,
                     text=extraction.text,
                     defined_term=defined_term
                 )
+
+                # Add normalized durations, if any
+                if hasattr(extraction, 'durations'):
+                    durations = [DurationNormalizedValues(unit = d.unit,
+                                                          value = d.value)
+                                 for d in extraction.durations]
+
+                    extraction_result.durations_normalized.extend(durations)
+
+                # Add normalized currencies, if any
+                if hasattr(extraction, 'currencies'):
+                    currencies = [CurrencyNormalizedValues(value = c.value,
+                                                           symbol = c.symbol,
+                                                           precision = c.precision)
+                                 for c in extraction.currencies]
+
+                    extraction_result.currencies_normalized.extend(currencies)
+
+                # Add normalized dates, if any
+                if hasattr(extraction, 'dates'):
+                    dates = [DateNormalizedValues(day = c.day,
+                                                  month = c.month,
+                                                  year = c.year)
+                                 for c in extraction.dates]
+
+                    extraction_result.dates_normalized.extend(dates)
 
                 if hasattr(extraction, 'spans'):
                     for span in extraction.spans:

--- a/zdai/models/field_extraction_result.py
+++ b/zdai/models/field_extraction_result.py
@@ -73,6 +73,33 @@ class FieldExtractionResultDefinedTerm:
 
 
 @dataclass
+class CurrencyNormalizedValues:
+    """
+    Dataclass to store the normalized currency values
+    """
+    value: float = None
+    symbol: str = None
+    precision: int = None
+
+
+@dataclass
+class DateNormalizedValues:
+    """
+    Dataclass to store the normalized date values
+    """
+    day: int = None
+    month: int = None
+    year: int = None
+
+@dataclass
+class DurationNormalizedValues:
+    """
+    Dataclass to store the duration date values
+    """
+    unit: str = None
+    value: int = None
+
+@dataclass
 class FieldExtractionResult:
     """
     Dataclass to store the properties associated with a field extraction result
@@ -81,3 +108,20 @@ class FieldExtractionResult:
     text: str = None
     spans: List[FieldExtractionResultSpan] = field(default_factory=lambda: [])
     defined_term: FieldExtractionResultDefinedTerm = None
+    durations_normalized: List[DurationNormalizedValues] = field(default_factory=lambda: [])
+    dates_normalized: List[DateNormalizedValues] = field(default_factory=lambda: [])
+    currencies_normalized: List[CurrencyNormalizedValues] = field(default_factory=lambda: [])
+
+    def is_normalized(self):
+        return any([self.durations_normalized, self.dates_normalized, self.currencies_normalized])
+
+    def get_normalized(self):
+        if not self.is_normalized():
+            return None, None
+
+        if self.durations_normalized:
+            return 'durations', self.durations_normalized
+        elif self.dates_normalized:
+            return 'dates', self.dates_normalized
+        elif self.currencies_normalized:
+            return 'currencies', self.currencies_normalized


### PR DESCRIPTION
DocAI now performs normalizations automatically as part of the field extraction service. Supported normalizations include dates, currencies and durations. This PR adds this to the field extraction's results class so that these normalized values are easily accessible.