### PR TITLE
Add setup.py to enable package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup
+setup(
+    name='zdai',
+    packages=['zdai', 'zdai.api', 'zdai.config', 'zdai.models'],
+    install_requires=[
+        'requests >= 2.31.0'
+    ]
+)


### PR DESCRIPTION
Hello,

I am proposing the addition of a setup.py file to the project. This will make it easier for developers to use the SDK in their own projects by allowing them to install it directly, instead of having to maintain a local copy of the SDK's code.

Here's how the command would look like for us:

```
pip install git+https://github.com/zuvaai/zdai-pythin.git@commit_hash
```

This setup.py file might not cover all the needs of the project (like classifiers, description, author, etc.), so please feel free to modify it as needed. However, this file already works locally for me. 

Thank you.