### PR TITLE
Add methods to retrieve documents in eOCR format

### DIFF
--- a/zdai/api/ocrapi.py
+++ b/zdai/api/ocrapi.py
@@ -91,6 +91,18 @@ class OCRAPI(object):
 
         return caller
 
+    def get_eocr(self, request_id: str) -> 'ApiCall':
+        """
+        Gets the file's layout in eOCR format
+
+        :return:
+        """
+
+        caller = self._call.new(method = 'GET', path = f'ocr/{request_id}/eocr')
+        caller.send()
+
+        return caller
+
     def get_layouts(self, request_id: str) -> 'ApiCall':
         """
         Gets the file's protobuf layout

--- a/zdai/models/ocr_request.py
+++ b/zdai/models/ocr_request.py
@@ -43,6 +43,10 @@ class OCRRequest(BaseRequest):
         data = self.api().get_images(request_id = self.id)
         return data
 
+    def get_eocr(self):
+        data = self.api().get_layouts(request_id = self.id)
+        return data
+
     def get_layouts(self):
         data = self.api().get_layouts(request_id = self.id)
         return data

--- a/zdai/models/ocr_request.py
+++ b/zdai/models/ocr_request.py
@@ -44,7 +44,7 @@ class OCRRequest(BaseRequest):
         return data
 
     def get_eocr(self):
-        data = self.api().get_layouts(request_id = self.id)
+        data = self.api().get_eocr(request_id = self.id)
         return data
 
     def get_layouts(self):


### PR DESCRIPTION
Adds `get_eocr` methods to `ocrapi.py` and `ocr_request.py`.
Allows users to retrieve document in eOCR format as opposed to the larger layouts protobuf.