### PR TITLE
Add support for LLM answers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ target/
 # Ignore user-specific zdai wrapper
 zdai/config/access.json
 
+# Ignore files from local build
+zdai.egg-info
+
 #Others
 .DS_Store
 test_script*

--- a/zdai/api/extractionapi.py
+++ b/zdai/api/extractionapi.py
@@ -35,12 +35,12 @@ class ExtractionAPI(object):
 
         :return:
         """
-        caller = self._call.new(method = 'POST', path = 'extraction')
-        caller.add_body(key = 'file_ids', value = file_ids)
-        caller.add_body(key = 'field_ids', value = field_ids)
+        caller = self._call.new(method='POST', path='extraction')
+        caller.add_body(key='file_ids', value=file_ids)
+        caller.add_body(key='field_ids', value=field_ids)
         caller.send()
 
-        return [FieldExtractionRequest(api = self, json = c) for c in caller.response.json().get('file_ids')], caller
+        return [FieldExtractionRequest(api=self, json=c) for c in caller.response.json().get('file_ids')], caller
 
     def get(self, request_id: str) -> Tuple[FieldExtractionRequest, ApiCall]:
         """
@@ -48,17 +48,17 @@ class ExtractionAPI(object):
 
         :return:
         """
-        caller = self._call.new(method = 'GET', path = f'extraction/{request_id}')
+        caller = self._call.new(method='GET', path=f'extraction/{request_id}')
         caller.send()
 
-        return FieldExtractionRequest(api = self, json = caller.response.json()), caller
+        return FieldExtractionRequest(api=self, json=caller.response.json()), caller
 
     def get_multiple(self, request_ids: List[str]) -> Tuple[List[FieldExtractionRequest], ApiCall]:
         """
         Gets multiple extraction statuses
 
         """
-        caller = self._call.new(method = 'GET', path = 'extractions')
+        caller = self._call.new(method='GET', path='extractions')
         caller.add_parameter('request_id', request_ids)
         caller.send()
 
@@ -69,7 +69,8 @@ class ExtractionAPI(object):
 
         for request_id, result in caller.response.json().get('statuses').items():
             result['request_id'] = request_id
-            field_extraction_requests.append(FieldExtractionRequest(api = self, json = result))
+            field_extraction_requests.append(
+                FieldExtractionRequest(api=self, json=result))
 
         return field_extraction_requests, caller
 
@@ -79,12 +80,14 @@ class ExtractionAPI(object):
 
         :return:
         """
-        caller = self._call.new(method = 'GET', path = f'extraction/{request_id}/results/text')
+        caller = self._call.new(
+            method='GET', path=f'extraction/{request_id}/results/text')
         caller.send()
 
         data = json.dumps(caller.response.json())
 
-        namespaces = json.loads(data, object_hook = lambda d: SimpleNamespace(**d))
+        namespaces = json.loads(
+            data, object_hook=lambda d: SimpleNamespace(**d))
 
         results = []
 
@@ -94,29 +97,30 @@ class ExtractionAPI(object):
             # If there's no extracted data for the Field, then append an empty field extraction result
             if not result.extractions:
                 # Regardless if there's extracted text, tag each result with a field_id.
-                results.append(FieldExtractionResult(field_id = result.field_id))
+                results.append(FieldExtractionResult(field_id=result.field_id))
                 continue
 
             # If there's extracted data for the Field, then create a new instance of FieldExtractionResult
             # for each of the entries. Append the spans list for each text extraction.
             for extraction in result.extractions:
-                extraction_result = FieldExtractionResult(field_id = result.field_id,
-                                                          text = extraction.text)
+                extraction_result = FieldExtractionResult(field_id=result.field_id,
+                                                          text=extraction.text)
 
                 if hasattr(extraction, 'spans'):
                     for span in extraction.spans:
                         extraction_span = FieldExtractionResultSpan(
-                                                    confidence=span.score,
-                                                    text_start = span.start,
-                                                    text_end = span.end,
-                                                    page_start = span.pages.start,
-                                                    page_end = span.pages.end,
-                                                    top = span.bounds.top,
-                                                    left = span.bounds.left,
-                                                    bottom = span.bounds.bottom,
-                                                    right = span.bounds.right)
+                            confidence=span.score,
+                            text_start=span.start,
+                            text_end=span.end,
+                            page_start=span.pages.start,
+                            page_end=span.pages.end,
+                            top=span.bounds.top,
+                            left=span.bounds.left,
+                            bottom=span.bounds.bottom,
+                            right=span.bounds.right)
                         for page in span.bboxes:
-                            extraction_span.bboxes.append(BoundingBoxesByPage(page))
+                            extraction_span.bboxes.append(
+                                BoundingBoxesByPage(page))
 
                         extraction_result.spans.append(extraction_span)
                 results.append(extraction_result)

--- a/zdai/api/fieldapi.py
+++ b/zdai/api/fieldapi.py
@@ -104,7 +104,7 @@ class FieldAPI(object):
                 recall=float(field.get('recall', 0.0)),
                 document_count=int(field.get('document_count', 0)),
                 is_custom=bool(field.get('is_custom')),
-                is_llm=bool(field.get('is_llm'))
+                has_answers=bool(field.get('has_answers'))
             ))
 
         return fields, caller

--- a/zdai/api/fieldapi.py
+++ b/zdai/api/fieldapi.py
@@ -103,7 +103,8 @@ class FieldAPI(object):
                 precision=float(field.get('precision', 0.0)),
                 recall=float(field.get('recall', 0.0)),
                 document_count=int(field.get('document_count', 0)),
-                is_custom=bool(field.get('is_custom'))
+                is_custom=bool(field.get('is_custom')),
+                is_llm=bool(field.get('is_llm'))
             ))
 
         return fields, caller

--- a/zdai/api/fieldapi.py
+++ b/zdai/api/fieldapi.py
@@ -32,14 +32,14 @@ class FieldAPI(object):
         """
         Creates a new field
         """
-        caller = self._call.new(method = 'POST', path = 'fields')
-        caller.add_body(key = 'field_name', value = field_name)
+        caller = self._call.new(method='POST', path='fields')
+        caller.add_body(key='field_name', value=field_name)
 
         if description:
-            caller.add_body(key = 'description', value = description)
+            caller.add_body(key='description', value=description)
 
         if from_field_id:
-            caller.add_body(key = 'from_field_id', value = from_field_id)
+            caller.add_body(key='from_field_id', value=from_field_id)
 
         caller.send()
 
@@ -68,41 +68,42 @@ class FieldAPI(object):
             ]
 
         """
-        caller = self._call.new(method = 'POST', path = f'fields/{field_id}/train')
+        caller = self._call.new(method='POST', path=f'fields/{field_id}/train')
         caller.set_body_value(annotations)
         caller.send()
 
-        return FieldTrainingRequest(api = self, json = caller.response.json()), caller
+        return FieldTrainingRequest(api=self, json=caller.response.json()), caller
 
     def get_training_status(self, field_id: str, request_id: int):
         """
         Obtain the latest status of the Field Training Request
         """
-        caller = self._call.new(method = 'GET', path = f'fields/{field_id}/train/{request_id}')
+        caller = self._call.new(
+            method='GET', path=f'fields/{field_id}/train/{request_id}')
         caller.send()
 
-        return FieldTrainingRequest(api = self, json = caller.response.json()), caller
+        return FieldTrainingRequest(api=self, json=caller.response.json()), caller
 
     def get(self) -> Tuple[List[Field], ApiCall]:
         """
         Gets the list of fields that exist in the ZDAI, which
         the API token has access to.
         """
-        caller = self._call.new(method = 'GET', path = 'fields')
+        caller = self._call.new(method='GET', path='fields')
         caller.send()
 
         fields = []
         for field in caller.response.json():
             fields.append(Field(
-                id = str(field.get('field_id')),
-                name = str(field.get('name')),
-                description = str(field.get('description')),
-                bias = float(field.get('bias', 0.0)),
-                f_score = float(field.get('f_score', 0.0)),
-                precision = float(field.get('precision', 0.0)),
-                recall = float(field.get('recall', 0.0)),
-                document_count = int(field.get('document_count', 0)),
-                is_custom = bool(field.get('is_custom'))
+                id=str(field.get('field_id')),
+                name=str(field.get('name')),
+                description=str(field.get('description')),
+                bias=float(field.get('bias', 0.0)),
+                f_score=float(field.get('f_score', 0.0)),
+                precision=float(field.get('precision', 0.0)),
+                recall=float(field.get('recall', 0.0)),
+                document_count=int(field.get('document_count', 0)),
+                is_custom=bool(field.get('is_custom'))
             ))
 
         return fields, caller
@@ -112,7 +113,8 @@ class FieldAPI(object):
         Gets the field's metadata
         """
 
-        caller = self._call.new(method = 'GET', path = f'fields/{field_id}/metadata')
+        caller = self._call.new(
+            method='GET', path=f'fields/{field_id}/metadata')
         caller.send()
 
         return FieldMetadata(**caller.response.json()), caller
@@ -122,9 +124,10 @@ class FieldAPI(object):
         Updates the field's metadata
         """
 
-        caller = self._call.new(method = 'PUT', path = f'fields/{field_id}/metadata')
-        caller.add_body(key = 'name', value = name)
-        caller.add_body(key = 'description', value = description)
+        caller = self._call.new(
+            method='PUT', path=f'fields/{field_id}/metadata')
+        caller.add_body(key='name', value=name)
+        caller.add_body(key='description', value=description)
         caller.send()
 
         return caller.response.status_code == 204, caller
@@ -134,7 +137,8 @@ class FieldAPI(object):
         Gets the field's accuracy (precision, recall, fscore)
         """
 
-        caller = self._call.new(method = 'GET', path = f'fields/{field_id}/accuracy')
+        caller = self._call.new(
+            method='GET', path=f'fields/{field_id}/accuracy')
         caller.send()
 
         return FieldAccuracy(**caller.response.json()), caller
@@ -144,19 +148,20 @@ class FieldAPI(object):
         Gets the field's validation details (type of instance (true positive, false positive, false negative) & location)
         """
 
-        caller = self._call.new(method = 'GET', path = f'fields/{field_id}/validation-details')
+        caller = self._call.new(
+            method='GET', path=f'fields/{field_id}/validation-details')
         caller.send()
 
         response = caller.response.json()
         validation_details = []
 
         for validation_detail in response:
-            location = FieldValidationLocation(character_start = validation_detail.get('location')[0],
-                                               character_end = validation_detail.get('location')[1])
+            location = FieldValidationLocation(character_start=validation_detail.get('location')[0],
+                                               character_end=validation_detail.get('location')[1])
 
-            v = FieldValidationDetails(file_id = validation_detail.get('file_id'),
-                                       type = validation_detail.get('type'),
-                                       location = location)
+            v = FieldValidationDetails(file_id=validation_detail.get('file_id'),
+                                       type=validation_detail.get('type'),
+                                       location=location)
 
             validation_details.append(v)
 

--- a/zdai/models/field.py
+++ b/zdai/models/field.py
@@ -29,3 +29,4 @@ class Field:
     recall: float
     document_count: int
     is_custom: bool
+    is_llm: bool

--- a/zdai/models/field.py
+++ b/zdai/models/field.py
@@ -23,10 +23,10 @@ class Field:
     id: str
     name: str
     description: str
-    bias: float
-    f_score: float
-    precision: float
-    recall: float
-    document_count: int
+    bias: float = None
+    f_score: float = None
+    precision: float = None
+    recall: float = None
+    document_count: int = None
     is_custom: bool
     is_llm: bool

--- a/zdai/models/field.py
+++ b/zdai/models/field.py
@@ -23,10 +23,10 @@ class Field:
     id: str
     name: str
     description: str
-    bias: float = None
-    f_score: float = None
-    precision: float = None
-    recall: float = None
-    document_count: int = None
+    bias: float
+    f_score: float
+    precision: float
+    recall: float
+    document_count: int
     is_custom: bool
     is_llm: bool

--- a/zdai/models/field.py
+++ b/zdai/models/field.py
@@ -29,4 +29,4 @@ class Field:
     recall: float
     document_count: int
     is_custom: bool
-    is_llm: bool
+    has_answers: bool

--- a/zdai/models/field_extraction_answer.py
+++ b/zdai/models/field_extraction_answer.py
@@ -12,23 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .baserequest import BaseRequest
+from dataclasses import dataclass
 
 
-class FieldExtractionRequest(BaseRequest):
+@dataclass
+class FieldExtractionAnswer:
     """
-    The class used for requests created in the Field Extraction service
+    Dataclass to store the properties associated with a field extraction anwers result
     """
-
-    def __init__(self, api, json):
-        super().__init__(api=api, json=json)
-
-    def get_results(self):
-        data, _ = self.api().get_result(request_id=self.id)
-
-        return data
-
-    def get_answers(self):
-        data, _ = self.api().get_answer(request_id=self.id)
-
-        return data
+    field_id: str = None
+    option: str = None
+    value: str = None

--- a/zdai/models/field_extraction_request.py
+++ b/zdai/models/field_extraction_request.py
@@ -19,10 +19,11 @@ class FieldExtractionRequest(BaseRequest):
     """
     The class used for requests created in the Field Extraction service
     """
+
     def __init__(self, api, json):
-        super().__init__(api = api, json = json)
+        super().__init__(api=api, json=json)
 
     def get_results(self):
-        data, _ = self.api().get_result(request_id = self.id)
+        data, _ = self.api().get_result(request_id=self.id)
 
         return data


### PR DESCRIPTION
- Add `get_answers` method to `FieldExtractionRequest`, which returns a list of `FieldExtractionAnswer` which contains `field_id`, `option`, `value` attributes.
- Update `Field` and `FieldAPI` to be compatible with changes introduced with LLM Answers fields.
- Format touched files with [autopep8](https://pypi.org/project/autopep8/).